### PR TITLE
Auto detect PWM_MAX_INPUT_US so it's not hardcoded to a single frequency

### DIFF
--- a/Router_PID/Router_PID.ino
+++ b/Router_PID/Router_PID.ino
@@ -130,11 +130,12 @@ void spindleRPM() {
 // rising() is called on the rising edge of the PHOTO_PIN. Basically starts the timer for measuring the
 // PWM duty cycle. ISR.
 void rising() {
+   int new_pulse = micros();
    // Capture when this is rising.
    if (MAX_PWM_INPUT_US == 0 && prev_time != 0) {
-     MAX_PWM_INPUT_US = (micros()-prev_time)*.99;
+     MAX_PWM_INPUT_US = (new_pulse-prev_time)*.99;
    }
-   prev_time = micros();
+   prev_time = new_pulse;
 
    // Set the next interrupt.
    attachInterrupt(digitalPinToInterrupt(PWM_PIN), falling, FALLING);

--- a/Router_PID/Router_PID.ino
+++ b/Router_PID/Router_PID.ino
@@ -132,7 +132,7 @@ void spindleRPM() {
 void rising() {
    // Capture when this is rising.
    if (MAX_PWM_INPUT_US == 0 && prev_time != 0) {
-     MAX_PWM_INPUT_US = micros()-prev_time;
+     MAX_PWM_INPUT_US = (micros()-prev_time)*.99;
    }
    prev_time = micros();
 

--- a/Router_PID/Router_PID.ino
+++ b/Router_PID/Router_PID.ino
@@ -132,13 +132,12 @@ void spindleRPM() {
 // rising() is called on the rising edge of the PHOTO_PIN. Basically starts the timer for measuring the
 // PWM duty cycle. ISR.
 void rising() {
-   // Ideally we store micros() in a local variable and use it instead of calling again but this is breaking things. 
-   // int new_pulse = micros();
+   unsigned long new_pulse = micros();
    // Capture when this is rising.
    if (MAX_PWM_INPUT_US == -1 && prev_time != 0) {
-     MAX_PWM_INPUT_US = (micros()-prev_time)*.99;
+     MAX_PWM_INPUT_US = (new_pulse-prev_time)*.99;
    }
-   prev_time = micros();
+   prev_time = new_pulse;
 
    // Set the next interrupt.
    attachInterrupt(digitalPinToInterrupt(PWM_PIN), falling, FALLING);

--- a/Router_PID/Router_PID.ino
+++ b/Router_PID/Router_PID.ino
@@ -130,12 +130,13 @@ void spindleRPM() {
 // rising() is called on the rising edge of the PHOTO_PIN. Basically starts the timer for measuring the
 // PWM duty cycle. ISR.
 void rising() {
-   int new_pulse = micros();
+   // Ideally we store micros() in a local variable and use it instead of calling again but this is breaking things. 
+   // int new_pulse = micros();
    // Capture when this is rising.
    if (MAX_PWM_INPUT_US == 0 && prev_time != 0) {
-     MAX_PWM_INPUT_US = (new_pulse-prev_time)*.99;
+     MAX_PWM_INPUT_US = (micros()-prev_time)*.99;
    }
-   prev_time = new_pulse;
+   prev_time = micros();
 
    // Set the next interrupt.
    attachInterrupt(digitalPinToInterrupt(PWM_PIN), falling, FALLING);

--- a/Router_PID/Router_PID.ino
+++ b/Router_PID/Router_PID.ino
@@ -44,7 +44,7 @@ double Kd=0.025;
 PID myPID(&Input, &Output, &Setpoint, Kp, Ki, Kd, DIRECT);                   // PID library
 
 const int MAX_TOOL_RPM = 30000;                                              // SETTINGS per "spindle" ?1k headroom needed?
-const int MAX_PWM_INPUT_US = 2024;                                           // Settings the microseconds of the max PWM from Marlin.
+int MAX_PWM_INPUT_US = 0;                                                    // Settings the microseconds of the max PWM from Marlin.
 
 void setup()
 {
@@ -131,6 +131,9 @@ void spindleRPM() {
 // PWM duty cycle. ISR.
 void rising() {
    // Capture when this is rising.
+   if (MAX_PWM_INPUT_US == 0 && prev_time != 0) {
+     MAX_PWM_INPUT_US = micros()-prev_time;
+   }
    prev_time = micros();
 
    // Set the next interrupt.


### PR DESCRIPTION
PWM_MAX_INPUT_US only works with ~490Hz as is. This pull request determines the correct PWM_PAX_INPUT_US and it has now been tested to work with my board running at ~50Hz

My only concern is I dont know is how map would behave with fromlow and fromhigh both being 0, but if it gives you the tohigh value then it should provide good behavior all around. In practice though on my board (A skr 1.3) at least it does not send true 100% duty cycle, there's still pulses so it's not an issue.